### PR TITLE
Can firmware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(longhorn_library_2024)
 
 set(CMAKE_CXX_STANDARD 17)
 
-file(GLOB_RECURSE SOURCES LIST_DIRECTORIES true *.h *.cpp)
+file(GLOB_RECURSE SOURCES LIST_DIRECTORIES true *.c *.h *.cpp)
 set(SOURCES ${SOURCES})
 
 add_library(longhorn_library_2024 ${SOURCES})

--- a/can.cpp
+++ b/can.cpp
@@ -1,8 +1,46 @@
 #include "can.h"
 
+std::unordered_map<uint16_t, CanRx*> can_mailboxes;
 
-void can_addMailbox(uint32_t id, CanRx* mailbox);
+void can_addMailbox(uint16_t id, CanRx* mailbox){
+  if(id > 0x7FF){
+    return;
+  }
+  if (can_mailboxes.find(id) != can_mailboxes.end()) {
+    return;
+  }
 
-void can_processRxFifo();
+  can_mailboxes[id] = mailbox;
+}
 
-void can_send(uint32_t id, uint8_t dlc, uint8_t data[8]);
+void can_processRxFifo(){
+  for(auto& [id, mailbox] : can_mailboxes){
+    if(mailbox->isRecent){
+      mailbox->isRecent = false;
+    }
+  }
+}
+
+void can_send(uint16_t id, uint8_t dlc, uint8_t data[8]);
+
+template<typename T>
+void read_packet(const uint8_t data[8], uint8_t start_byte, uint8_t end_byte, T& dest){
+  if (start_byte > end_byte || end_byte > 7 || start_byte > 7) {
+    return;
+  }
+  uint64_t value = 0;
+  for(int i = start_byte; i <= end_byte; i++){
+    value |= static_cast<uint64_t>(data[i]) << (8 * (i - start_byte));;
+  }
+  dest = static_cast<T>(value);
+}
+
+template<typename U>
+void write_packet(uint8_t data[8], uint8_t start_byte, uint8_t end_byte, U value){
+  if (start_byte > end_byte || end_byte > 7 || start_byte > 7) {
+    return;
+  }
+  for(int i = start_byte; i <= end_byte; i++){
+    data[i] = static_cast<uint8_t>(value >> (8 * (i - start_byte)));
+  }
+}

--- a/can.h
+++ b/can.h
@@ -2,7 +2,6 @@
 #define LONGHORN_LIBRARY_2024_CAN_H
 
 #include <cstdint>
-#include <unordered_map>
 // CAN IDs
 // Inverter predefined CAN IDs
 #define INV_TEMP1_DATA 0x0A0 //Stores inverter module temperature
@@ -41,14 +40,21 @@ typedef struct CanRx {
     uint8_t data[8];
 } CanRx;
 
-extern std::unordered_map<uint16_t, CanRx*> can_mailboxes;
 /**
  * Tell the CAN driver to copy all incoming packets with a given ID to the given mailbox address.
  * Mailbox must be pre-defined
- * @param id ID of the CAN packets.
+ * @param id ID of the CAN packets you want to add
+ * @param mask Mask of the CAN packets you want to add
  * @param mailbox Pointer to where the incoming packet is stored.
  */
-void can_addMailbox(uint16_t id, CanRx* mailbox);
+void can_addMailbox(uint16_t id, uint16_t mask, CanRx* mailbox);
+
+/**
+ * Get the mailbox associated with the ID
+ * @param id ID of the CAN packet.
+ * @return Pointer to the associated mailbox, returns null if it doesn't exist
+ */
+CanRx* can_getMailbox(uint16_t id);
 
 /**
  * Empty the Rx FIFO and update the corresponding mailboxes.

--- a/can.h
+++ b/can.h
@@ -1,10 +1,10 @@
 #ifndef LONGHORN_LIBRARY_2024_CAN_H
 #define LONGHORN_LIBRARY_2024_CAN_H
 
-#include <stdint.h>
-
+#include <cstdint>
+#include <unordered_map>
 // CAN IDs
-
+// Inverter predefined CAN IDs
 #define INV_TEMP1_DATA 0x0A0 //Stores inverter module temperature
 #define INV_TEMP3_DATA 0x0A2 //Stores motor temperature
 #define INV_MOTOR_POSITIONS 0x0A5 //Stores motor position
@@ -15,12 +15,19 @@
 #define INV_TORQUE_TIMER 0x0AC //Stores inverter torque results
 #define INV_HIGH_SPEED_MSG 0x0B0 //Stores inverter high speed message
 #define VCU_INV_COMMAND 0x0C0 //Stores inverter command
-#define VCU_INV_PARAMETER_RW 0x0C1 //Sets inverter parameter r/w
-#define INV_VCU_RESPONSE_RW 0x0C2 //Responds back success of parameter r/w
+#define VCU_INV_PARAMS_REQUEST 0x0C1 //Sets inverter parameter r/w
+#define INV_VCU_PARAMS_RESPONSE 0x0C2 //Responds back success of parameter r/w
 
+// VCU CAN IDs
+#define VCU_DASH_FAULT_INFO 0x110 //Sends out VCU fault info to dash
+
+//Parameters to set to boards (unused currently)
 #define VCU_HVC_PARAMS 0x0F0
 #define VCU_PDU_PARAMS 0x0F1
+#define VCU_WHS_PARAMS 0x0F2
+#define VCU_UPR_PARAMS 0x0F3
 
+// HVC CAN IDs
 #define HVC_VCU_CELL_VOLTAGES_START 0x300 // 0x300-0x37F
 #define HVC_VCU_CELL_TEMPS_START 0x380 // 0x380-0x3FF
 
@@ -34,12 +41,14 @@ typedef struct CanRx {
     uint8_t data[8];
 } CanRx;
 
+extern std::unordered_map<uint16_t, CanRx*> can_mailboxes;
 /**
  * Tell the CAN driver to copy all incoming packets with a given ID to the given mailbox address.
+ * Mailbox must be pre-defined
  * @param id ID of the CAN packets.
  * @param mailbox Pointer to where the incoming packet is stored.
  */
-void can_addMailbox(uint32_t id, CanRx* mailbox);
+void can_addMailbox(uint16_t id, CanRx* mailbox);
 
 /**
  * Empty the Rx FIFO and update the corresponding mailboxes.
@@ -49,6 +58,16 @@ void can_processRxFifo();
 /**
  * Put a CAN packet in the Tx FIFO.
  */
-void can_send(uint32_t id, uint8_t dlc, uint8_t data[8]);
+void can_send(uint16_t id, uint8_t dlc, uint8_t data[8]);
+
+/**
+ * Read a parameter from the packet, specifying which bytes to read.
+ * This assumes that the packets are little endian, which is the standard set in CM200dz
+ */
+template <typename T>
+void read_packet(const uint8_t data[8], uint8_t start_byte, uint8_t end_byte, T& dest);
+
+template<typename U>
+void write_packet(uint8_t data[8], uint8_t start_byte, uint8_t end_byte, U value);
 
 #endif //LONGHORN_LIBRARY_2024_CAN_H


### PR DESCRIPTION
Added CAN Mailbox logic so that interrupts can store in correct data buffers

Added more CAN IDs, which will be accessible to any chip on the car